### PR TITLE
digit toleration

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function lrcParser(data) {
   // split a long stirng into lines by system's end-of-line marker line \r\n on Windows
   // or \n on POSIX
   let lines = data.split(EOL)
-  const timeStart = /\[(.{2}\:.{5})\]/ // i.g [00:10.55]
+  const timeStart = /\[(\d*\:\d*\.?\d*)\]/ // i.g [00:10.55]
   const scriptText = /(.+)/ // Havana ooh na-na (ayy) 
   const timeEnd = timeStart
   const startAndText = new RegExp(timeStart.source + scriptText.source)


### PR DESCRIPTION
Tolerate a widened range of digits involved in the time tag like `[00:10.710]`.